### PR TITLE
fix: too many pods being spawned if exception is not handled

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -222,7 +222,12 @@ async def on_ready():
     # Get guild data
     guild = client.get_guild(int(config["guild_id"]))
     # Fetch events
-    events = get_ctftime_events()
+    try:
+        events = get_ctftime_events()
+    except Exception as e:
+        logging.error("Got exception fetching ctftime events")
+        logging.error(e)
+        sys.exit(1)
     # Create new events
     await create_discord_events(guild, events)
     logging.info("Events successfully created.")

--- a/charts/matemann/templates/cronjobs.yaml
+++ b/charts/matemann/templates/cronjobs.yaml
@@ -9,8 +9,8 @@ spec:
   concurrencyPolicy: {{ .Values.concurrencyPolicy | quote }}
   jobTemplate:
     spec:
-      activeDeadlineSeconds: {{ .Values.activeDeadlineSeconds | quote }}
-      backoffLimit: {{ .Values.backoffLimit | quote }}
+      activeDeadlineSeconds: {{ .Values.activeDeadlineSeconds }}
+      backoffLimit: {{ .Values.backoffLimit }}
       template:
         spec:
           restartPolicy: Never

--- a/charts/matemann/templates/cronjobs.yaml
+++ b/charts/matemann/templates/cronjobs.yaml
@@ -6,8 +6,11 @@ metadata:
     {{- include "matemann.labels" . | nindent 4 }}
 spec:
   schedule: {{ .Values.schedule | quote }}
+  concurrencyPolicy: {{ .Values.concurrencyPolicy | quote }}
   jobTemplate:
     spec:
+      activeDeadlineSeconds: {{ .Values.activeDeadlineSeconds | quote }}
+      backoffLimit: {{ .Values.backoffLimit | quote }}
       template:
         spec:
           restartPolicy: Never

--- a/charts/matemann/values.yaml
+++ b/charts/matemann/values.yaml
@@ -9,6 +9,9 @@ matemann:
     minWeight: "0.0"
 
 schedule: "*/1 * * * *"
+concurrencyPolicy: Replace
+backoffLimit: 6
+activeDeadlineSeconds: 600
 
 image:
   repository: ghcr.io/gianklug/matemann


### PR DESCRIPTION
Currently, if an exception occurs if contacting ctftime.org, the pod lives on forever and does not exit. This PR tries to fix that by killing the pod after a specific time and also replacing the Job if a new Job gets scheduled by the Cronjob. 